### PR TITLE
Adds `list` command in favor of `clusters`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,36 +7,30 @@
 
 
 ## Login to Tanzu Supervisor Cluster
-The `login` command will authenticate the user using username/password. This will store session credentials in a temporary kubeconfig file. It's temporary because we will use the kubeconfig file with other commands without having to provide credentials each time.
-
+The `login` command will authenticate the user using their SSO credentials. 
 ```bash
-tcli login -s https://supervisor.local -u bobby -p 'MyP5ssW0rD'
+tcli login -s https://supervisor.local -u beyonce -p 'MyP5ssW0rD'
 ```
 
-## Flag values in env vars
-You can use environment variables prefixed with `TCLI_` so that you don't have to provide flags for each command. For example:
-```bash
-export TCLI_SERVER="https://supervisor.local"
-export TCLI_USERNAME="bobby"
-export TCLI_PASSWORD="MyP5ssW0rD"
-$ tcli login
-$ tcli clusters
-```
-
-## List clusters within a namespace
-After you have logged in, the cli will print a list of namespaces your account has access to. You may list clusters within each namespace with following. If no namespace is defined, then "default" will be used.
-```bash
-tcli clusters -n dev
-```
-
-## Login to a cluster
-The architecture of Tanzu does not allow you to use the same credentials for the supervisor cluster and guest clusters. So we have to log in to each cluster separately. You can do this easily with following
+**Pro Tip!** You can use environment variables prefixed with `TCLI_` so that you don't have to provide them for each command. For example:
 
 ```bash
-tcli login -n mynamespace -c mycluster
+# Listing namespaces 
+$ tcli list namespaces
+beyonces-ns
+cardis-ns
+
+# Listing clusters
+$ tcli list clusters -n beyonces-ns
+NAME          CONTROL PLANE   WORKER   TKR NAME                           AGE     READY   TKR COMPATIBLE   UPDATES AVAILABLE
+beyonce-test   1               2        v1.22.9---vmware.1-tkg.1.cc71bc8   21d     True    True             [1.23.8+vmware.3-tkg.1]
+beyonce-prod   1               2        v1.21.6---vmware.1-tkg.1.b3d708a   15d     True    True             [1.22.9+vmware.1-tkg.1.cc71bc8]
+
+# Login to a cluster 
+$ tcli login beyonce-prod -n beyonces-ns
 ```
 
-The login command will update your `kubeconfig` by adding data so you can continue interacting with the clusters using `kubectl`
+*The architecture of Tanzu does not allow you to use the same credentials for the supervisor cluster and guest clusters. So we have to log in to each cluster separately*
 
 ## CLI Usage
 ```

--- a/cmd/inspect/inspect.go
+++ b/cmd/inspect/inspect.go
@@ -20,10 +20,16 @@ var (
 
 func NewCmdInspect() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "inspect",
+		Use:   "inspect CLUSTER",
 		Short: "Inspect a specific cluster within a namespace",
 		Args:  cobra.ExactArgs(1),
-		Long:  "",
+		Long: `Inspect a specific cluster within a namespace
+Examples:
+	# Inspecting will return the raw cluster specification in YAML format
+	tcli inspect NAME -n NAMESPACE
+
+	Use "tcli --help" for a list of global command-line options (applies to all commands).
+	`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := viper.BindPFlags(cmd.Flags()); err != nil {
 				return err

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -24,7 +24,16 @@ func NewCmdList() *cobra.Command {
 		Aliases: []string{"ls"},
 		Args:    cobra.ExactArgs(1),
 		Short:   "List clusters and namespaces",
-		Long:    "",
+		Long: `List clusters and namespaces
+Examples:
+	# List namespaces
+	tcli list namespaces
+
+	# List clusters in a namespace
+	tcli list clusters -n NAMESPACE
+
+	Use "tcli --help" for a list of global command-line options (applies to all commands).
+	`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := viper.BindPFlags(cmd.Flags()); err != nil {
 				return err

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -1,13 +1,16 @@
-package clusters
+package list
 
 import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
+	"strings"
 
 	"github.com/middlewaregruppen/tcli/pkg/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -15,11 +18,13 @@ var (
 	tanzuNamespace string
 )
 
-func NewCmdClusters() *cobra.Command {
+func NewCmdList() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "clusters",
-		Short: "List clusters within a Tanzu namespace",
-		Long:  "",
+		Use:     "list RESOURCE",
+		Aliases: []string{"ls"},
+		Args:    cobra.ExactArgs(1),
+		Short:   "List clusters and namespaces",
+		Long:    "",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := viper.BindPFlags(cmd.Flags()); err != nil {
 				return err
@@ -30,6 +35,7 @@ func NewCmdClusters() *cobra.Command {
 
 			tanzuServer := viper.GetString("server")
 			tanzuUsername := viper.GetString("username")
+			tanzuPassword := viper.GetString("password")
 			insecureSkipVerify := viper.GetBool("insecure")
 			kubeconfig := viper.GetString("kubeconfig")
 
@@ -74,15 +80,41 @@ func NewCmdClusters() *cobra.Command {
 				tanzuNamespace = conf.Contexts[contextName].Namespace
 			}
 
-			clusterlist, err := c.Clusters(tanzuNamespace)
-			if err != nil {
-				return err
+			a := strings.ToLower(args[0])
+
+			// Print list of namespaces
+			if a == "namespaces" || a == "ns" {
+				err = c.Login(tanzuUsername, tanzuPassword)
+				if err != nil {
+					return err
+				}
+				nsList, err := c.Namespaces()
+				if err != nil {
+					return err
+				}
+				for _, n := range nsList {
+					fmt.Println(n.Namespace)
+				}
 			}
 
-			fmt.Printf("%d clusters in %s:\n", len(clusterlist.Items), tanzuNamespace)
-			for _, n := range clusterlist.Items {
-				fmt.Println(n.Name)
+			// Print list of clusters
+			if a == "clusters" || a == "clu" {
+				objs, err := c.Clusters(tanzuNamespace)
+				if err != nil {
+					return err
+				}
+				printer := printers.NewTablePrinter(printers.PrintOptions{})
+				err = printer.PrintObj(objs, os.Stdout)
+				if err != nil {
+					return err
+				}
 			}
+
+			// clusterlist, err := c.Clusters(tanzuNamespace)
+			// if err != nil {
+			// 	return err
+			// }
+
 			return nil
 		},
 	}

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -14,15 +14,30 @@ import (
 )
 
 var (
-	tanzuCluster   string
 	tanzuNamespace string
 )
 
 func NewCmdLogin() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "login",
+		Use:   "login CLUSTER",
+		Args:  cobra.MaximumNArgs(1),
 		Short: "Authenticate user with Tanzu namespaces and clusters",
-		Long:  "",
+		Long: `Authenticate user with Tanzu namespaces and clusters
+Examples:
+	# Login to the supervisor cluster
+	tcli -s SERVER -u USER -p PASSWORD login
+
+	# Flags can be prefixed with TCLI_ and therefore omitted from the command line
+	export TCLI_SERVER=https://supervisor.local
+	export TCLI_USERNAME=bob
+	export TCLI_PASSWORD=mypassword
+	tcli login
+
+	# Login to a tanzu cluster in a namespace
+	tcli login CLUSTER -n NAMESPACE
+
+	Use "tcli --help" for a list of global command-line options (applies to all commands).
+	`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := viper.BindPFlags(cmd.Flags()); err != nil {
 				return err
@@ -34,7 +49,6 @@ func NewCmdLogin() *cobra.Command {
 			tanzuServer := viper.GetString("server")
 			tanzuUsername := viper.GetString("username")
 			tanzuPassword := viper.GetString("password")
-			tanzuCluster := viper.GetString("cluster")
 			tanzuNamespace := viper.GetString("namespace")
 			insecureSkipVerify := viper.GetBool("insecure")
 			kubeconfig := viper.GetString("kubeconfig")
@@ -93,7 +107,8 @@ func NewCmdLogin() *cobra.Command {
 			}
 
 			// Login to cluster if both flags are present
-			if len(tanzuCluster) > 0 && len(tanzuNamespace) > 0 {
+			if len(args) > 0 && len(tanzuNamespace) > 0 {
+				tanzuCluster := args[0]
 				res, err := c.LoginCluster(tanzuCluster, tanzuNamespace)
 				if err != nil {
 					return err
@@ -139,7 +154,6 @@ func NewCmdLogin() *cobra.Command {
 			return nil
 		},
 	}
-	c.Flags().StringVarP(&tanzuCluster, "cluster", "c", "", "Name of the Tanzu Kubernetes Cluster to authenticate against.")
 	c.Flags().StringVarP(&tanzuNamespace, "namespace", "n", "", "Namespace in which the Tanzu Kubernetes cluster resides.")
 	return c
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/middlewaregruppen/tcli/cmd/clusters"
 	"github.com/middlewaregruppen/tcli/cmd/inspect"
+	"github.com/middlewaregruppen/tcli/cmd/list"
 	"github.com/middlewaregruppen/tcli/cmd/login"
 	"github.com/middlewaregruppen/tcli/cmd/logout"
 	"github.com/middlewaregruppen/tcli/cmd/version"
@@ -86,8 +86,8 @@ func NewDefaultCommand() *cobra.Command {
 	c.AddCommand(version.NewCmdVersion())
 	c.AddCommand(login.NewCmdLogin())
 	c.AddCommand(logout.NewCmdLogout())
-	c.AddCommand(clusters.NewCmdClusters())
 	c.AddCommand(inspect.NewCmdInspect())
+	c.AddCommand(list.NewCmdList())
 
 	return c
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,14 @@ func NewDefaultCommand() *cobra.Command {
 		Long: `A command line tool that simplifies authentication to Tanzu namespaces and clusters.
 	tcli is a simple CLI tool to:
 	- Simplify login process over the default vpshere plugin
+
+	Flags can be prefixed with TCLI_ and therefore omitted from the command line
+	
+	export TCLI_SERVER=https://supervisor.local
+	export TCLI_USERNAME=bob
+	export TCLI_PASSWORD=mypassword
+
+	Use "tcli --help" for a list of global command-line options (applies to all commands).
 	`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			logrus.SetOutput(os.Stdout)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0
 	github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68
+	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/cli-runtime v0.24.0
 	k8s.io/client-go v0.24.2
 )
 
@@ -38,6 +40,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
@@ -71,7 +74,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.24.2 // indirect
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/apimachinery v0.24.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -356,6 +356,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -1054,6 +1055,7 @@ k8s.io/apimachinery v0.24.0/go.mod h1:82Bi4sCzVBdpYjyI4jY6aHX+YCUchUIrZrXKedjd2U
 k8s.io/apimachinery v0.24.2 h1:5QlH9SL2C8KMcrNJPor+LbXVTaZRReml7svPEh4OKDM=
 k8s.io/apimachinery v0.24.2/go.mod h1:82Bi4sCzVBdpYjyI4jY6aHX+YCUchUIrZrXKedjd2UM=
 k8s.io/apiserver v0.24.2/go.mod h1:pSuKzr3zV+L+MWqsEo0kHHYwCo77AT5qXbFXP2jbvFI=
+k8s.io/cli-runtime v0.24.0 h1:ot3Qf49T852uEyNApABO1UHHpFIckKK/NqpheZYN2gM=
 k8s.io/cli-runtime v0.24.0/go.mod h1:9XxoZDsEkRFUThnwqNviqzljtT/LdHtNWvcNFrAXl0A=
 k8s.io/client-go v0.24.0/go.mod h1:VFPQET+cAFpYxh6Bq6f4xyMY80G6jKKktU6G0m00VDw=
 k8s.io/client-go v0.24.2 h1:CoXFSf8if+bLEbinDqN9ePIDGzcLtqhfd6jpfnwGOFA=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 
 	"github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type RestClient struct {
@@ -85,7 +86,7 @@ func (r *RestClient) Namespaces() ([]Namespace, error) {
 	return namespaces, nil
 }
 
-func (r *RestClient) Clusters(ns string) (*v1alpha2.TanzuKubernetesClusterList, error) {
+func (r *RestClient) Clusters(ns string) (*v1.Table, error) {
 	if len(ns) == 0 {
 		ns = "default"
 	}
@@ -95,6 +96,7 @@ func (r *RestClient) Clusters(ns string) (*v1alpha2.TanzuKubernetesClusterList, 
 	}
 	req.Header = map[string][]string{
 		"Content-Type":  {"application/json"},
+		"Accept":        {"application/json;as=Table;g=meta.k8s.io;v=v1"},
 		"Authorization": {fmt.Sprintf("Bearer %s", r.Token)},
 	}
 	resp, err := r.c.Do(req)
@@ -105,7 +107,8 @@ func (r *RestClient) Clusters(ns string) (*v1alpha2.TanzuKubernetesClusterList, 
 	if err != nil {
 		return nil, err
 	}
-	var clusterlist v1alpha2.TanzuKubernetesClusterList
+	//var clusterlist v1alpha2.TanzuKubernetesClusterList
+	var clusterlist v1.Table
 	err = json.Unmarshal(body, &clusterlist)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Instead of the clusters command we now have `list` which lists different resources specified by the first argument to the command. For example `tcli list clusters`