### PR TITLE
Read password from stdin where it's needed

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -6,10 +6,12 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"syscall"
 
 	"github.com/middlewaregruppen/tcli/pkg/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/term"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -98,6 +100,16 @@ Examples:
 			a := strings.ToLower(args[0])
 			switch a {
 			case "namespaces", "ns":
+				// Read from stdin if password isn't set anywhere
+				if len(tanzuPassword) == 0 {
+					fmt.Printf("Password:")
+					bytePassword, err := term.ReadPassword(int(syscall.Stdin))
+					if err != nil {
+						return err
+					}
+					tanzuPassword = string(bytePassword)
+					fmt.Printf("\n")
+				}
 				return listNamespaces(c, tanzuUsername, tanzuPassword)
 			case "clusters", "clu", "tkc":
 				return listClusters(c, tanzuNamespace)

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -4,10 +4,12 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/url"
+	"syscall"
 
 	"github.com/middlewaregruppen/tcli/pkg/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/term"
 
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -48,6 +50,19 @@ Examples:
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := viper.BindPFlags(cmd.Flags()); err != nil {
 				return err
+			}
+			// Read from stdin if password isn't set anywhere
+			if len(viper.GetString("password")) == 0 {
+				fmt.Printf("Password:")
+				bytePassword, err := term.ReadPassword(int(syscall.Stdin))
+				if err != nil {
+					return err
+				}
+				err = cmd.Flags().Set("password", string(bytePassword))
+				if err != nil {
+					return err
+				}
+				fmt.Printf("\n")
 			}
 			return nil
 		},
@@ -92,6 +107,7 @@ Examples:
 			context := api.NewContext()
 			context.Cluster = u.Host
 			context.AuthInfo = authName
+			context.Namespace = ns[len(ns)-1].Namespace
 
 			// Read kubeconfig from file
 			conf, err := clientcmd.LoadFromFile(kubeconfig)
@@ -101,6 +117,7 @@ Examples:
 			conf.Clusters[u.Host] = cluster
 			conf.AuthInfos[authName] = auth
 			conf.Contexts[u.Host] = context
+			conf.CurrentContext = u.Host
 
 			// Write back to kubeconfig
 			err = clientcmd.WriteToFile(*conf, kubeconfig)

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -107,7 +107,9 @@ Examples:
 			context := api.NewContext()
 			context.Cluster = u.Host
 			context.AuthInfo = authName
-			context.Namespace = ns[len(ns)-1].Namespace
+			if len(ns) > 0 {
+				context.Namespace = ns[len(ns)-1].Namespace
+			}
 
 			// Read kubeconfig from file
 			conf, err := clientcmd.LoadFromFile(kubeconfig)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"syscall"
 
 	"github.com/middlewaregruppen/tcli/cmd/inspect"
 	"github.com/middlewaregruppen/tcli/cmd/list"
@@ -12,7 +11,6 @@ import (
 	"github.com/middlewaregruppen/tcli/cmd/logout"
 	"github.com/middlewaregruppen/tcli/cmd/version"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/term"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -62,20 +60,6 @@ func NewDefaultCommand() *cobra.Command {
 
 			if err := viper.BindPFlags(cmd.Flags()); err != nil {
 				return err
-			}
-
-			// Read from stdin if password isn't set anywhere
-			if viper.GetString("password") == "" {
-				fmt.Printf("Password:")
-				bytePassword, err := term.ReadPassword(int(syscall.Stdin))
-				if err != nil {
-					return err
-				}
-				err = cmd.Flags().Set("password", string(bytePassword))
-				if err != nil {
-					return err
-				}
-				fmt.Printf("\n")
 			}
 
 			// Check if kubeconfig exists, create if it doesn't


### PR DESCRIPTION
* Having to read password from stdin leads to unexpected behaviour, such as that user beeing prompted for password when running `tcli version` which is not what we want. This change so that password prompt appears only when it's needed.
* Logging in to a supervisor cluster will update the current context in the kubeconfig file. The current context will be set to the last namespace returned by the server after a login operation.