### PR TITLE
refactor(logging): migrate from logrus to slog

### DIFF
--- a/cmd/internal/auth/auth.go
+++ b/cmd/internal/auth/auth.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
-	"os"
 
 	"github.com/middlewaregruppen/tcli/pkg/client"
 	"k8s.io/client-go/tools/clientcmd"
@@ -40,10 +39,9 @@ func ClientFromKubeconfig(server, kubeconfigPath, username string, insecure bool
 		return nil, "", err
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	c, err := client.New(
 		server,
-		client.WithLogger(logger),
+		client.WithLogger(slog.Default()),
 		client.WithCredentials(client.TokenCredentials(token)),
 		client.WithInsecure(insecure),
 	)

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
-	"os"
 	"syscall"
 
 	"github.com/middlewaregruppen/tcli/pkg/client"
@@ -92,10 +91,9 @@ Examples:
 			// the port if the user supplied tanzuServer with an explicit port.
 			supervisorK8sServer := fmt.Sprintf("https://%s:6443", u.Hostname())
 
-			logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 			c, err := client.New(
 				tanzuServer,
-				client.WithLogger(logger),
+				client.WithLogger(slog.Default()),
 				client.WithCredentials(client.BasicCredentials(tanzuUsername, tanzuPassword)),
 				client.WithInsecure(insecureSkipVerify),
 			)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/middlewaregruppen/tcli/cmd/logout"
 	"github.com/middlewaregruppen/tcli/cmd/use"
 	"github.com/middlewaregruppen/tcli/cmd/version"
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -25,7 +25,7 @@ var (
 	tanzuUsername      string
 	tanzuPassword      string
 	insecureSkipVerify bool
-	verbosity          string
+	debug              bool
 	kubeconfig         string
 	timeout            time.Duration
 )
@@ -55,12 +55,11 @@ func NewDefaultCommand() *cobra.Command {
 	Use "tcli --help" for a list of global command-line options (applies to all commands).
 	`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			logrus.SetOutput(os.Stdout)
-			lvl, err := logrus.ParseLevel(verbosity)
-			if err != nil {
-				return err
+			level := slog.LevelWarn
+			if debug {
+				level = slog.LevelDebug
 			}
-			logrus.SetLevel(lvl)
+			slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
 
 			if err := viper.BindPFlags(cmd.Flags()); err != nil {
 				return err
@@ -84,11 +83,12 @@ func NewDefaultCommand() *cobra.Command {
 
 	homedir, err := os.UserHomeDir()
 	if err != nil {
-		logrus.Fatal(err)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
 	}
 	// Setup flags
 	c.PersistentFlags().DurationVar(&timeout, "timeout", 30*time.Second, "How long to wait for an operation before giving up")
-	c.PersistentFlags().StringVarP(&verbosity, "verbosity", "v", "info", "number for the log level verbosity (debug, info, warn, error, fatal, panic)")
+	c.PersistentFlags().BoolVar(&debug, "debug", false, "Enable debug logging (HTTP traces written to stderr)")
 	c.PersistentFlags().StringVarP(&tanzuServer, "server", "s", "", "Address of the server to authenticate against.")
 	c.PersistentFlags().StringVarP(&tanzuUsername, "username", "u", "", "Username to authenticate.")
 	c.PersistentFlags().StringVarP(&tanzuPassword, "password", "p", "", "Password to use for authentication.")

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/middlewaregruppen/tcli
 go 1.19
 
 require (
-	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0
 	github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-20230419030809-7081502ebf68

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,6 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
-github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -789,7 +787,6 @@ golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -1,15 +1,15 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/middlewaregruppen/tcli/cmd"
-	"github.com/sirupsen/logrus"
 )
 
 func main() {
 	if err := cmd.NewDefaultCommand().Execute(); err != nil {
-		logrus.Error(err)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 	os.Exit(0)


### PR DESCRIPTION
Replaces logrus with Go's standard slog package for logging. Removes logrus dependency and updates logging initialization and error handling. This simplifies logging configuration and reduces external dependencies.